### PR TITLE
Add definitions for TypeScript

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "pack": "webpack --mode production --config webpack.config.js"
   },
   "main": "src/scripts/index.js",
+  "types": "src/scripts/index.d.ts",
   "unpkg": "dist/image-compare-viewer.min.js",
   "repository": {
     "type": "git",

--- a/src/scripts/index.d.ts
+++ b/src/scripts/index.d.ts
@@ -1,0 +1,71 @@
+export interface ImageCompareOptions {
+  // UI Theme Defaults
+  /**
+   * @default "#FFFFFF"
+   */
+  controlColor?: string;
+  /**
+   * @default true
+   */
+  controlShadow?: boolean;
+  /**
+   * @default false
+   */
+  addCircle?: boolean;
+  /**
+   * @default true
+   */
+  addCircleBlur?: boolean;
+  // Label Defaults
+  /**
+   * @default false
+   */
+  showLabels?: boolean;
+  labelOptions?: {
+    /**
+     * @default 'Before'
+     */
+    before?: string;
+    /**
+     * @default 'After'
+     */
+    after?: string;
+    /**
+     * @default false
+     */
+    onHover?: boolean;
+  };
+  // Smoothing
+  /**
+   * @default true
+   */
+  smoothing?: boolean;
+  /**
+   * @default 100
+   */
+  smoothingAmount?: number;
+  // Other options
+  /**
+   * @default false
+   */
+  hoverStart?: boolean;
+  /**
+   * @default false
+   */
+  verticalMode?: boolean;
+  /**
+   * @default 50
+   */
+  startingPoint?: number;
+  /**
+   * @default false
+   */
+  fluidMode?: boolean;
+}
+
+declare class ImageCompare {
+  constructor(element: HTMLElement, options?: ImageCompareOptions);
+  mount(): void;
+}
+
+export default ImageCompare;


### PR DESCRIPTION
What about adding the definitions for TypeScript?

That way, for example, we could have type checking and intellisense suggestions with something like this:

```TypeScript
import ImageCompare from 'image-compare-viewer';

new ImageCompare(el, {
    // options
}).mount();
```
